### PR TITLE
Install on Windows with bundled DLL.

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1,0 +1,38 @@
+use Panda::Builder;
+
+use Shell::Command;
+use LWP::Simple;
+use NativeCall;
+
+class Build is Panda::Builder {
+    method build($workdir) {
+        # We only have a .dll file bundled on Windows; non-windows is assumed
+        # to have a libarchive already.
+        return unless $*DISTRO.is-win;
+
+        my constant $file = "libarchive.dll";
+        my constant $hash = "E6836E32802555593AEDAFE1CC00752CBDA0EBCE051500B1AA37847C30EFF161";
+
+        # to avoid a dependency (and because Digest::SHA is too slow), we do a hacked up powershell hash
+        # this should work all the way back to powershell v1
+        my &ps-hash = -> $path {
+            my $fn = 'function get-sha256 { param($file);[system.bitconverter]::tostring([System.Security.Cryptography.sha256]::create().computehash([system.io.file]::openread((resolve-path $file)))) -replace \"-\",\"\" } ';
+            my $out = qqx/powershell -noprofile -Command "$fn get-sha256 $path"/;
+            $out.lines.grep({$_.chars})[*-1];
+        }
+        say 'Installing bundled libarchive.';
+
+        my $basedir = $workdir ~ '\resources';
+
+        say "Fetching $file";
+        my $blob = LWP::Simple.get("http://www.p6c.org/~jnthn/libarchive/$file");
+        say "Writing $file";
+        spurt("$basedir\\$file", $blob);
+
+        say "Verifying $file";
+        my $got-hash = ps-hash("$basedir\\$file");
+        if ($got-hash ne $hash) {
+            die "Bad download of $file (got: $got-hash; expected: $hash)";
+        }
+    }
+}

--- a/META6.json
+++ b/META6.json
@@ -1,14 +1,16 @@
 {
   "perl" : "6.c",
   "name" : "Archive::Libarchive::Raw",
-  "version" : "0.0.1",
+  "version" : "0.0.2",
   "description" : "Raw interface to libarchive",
+  "build-depends" : [ "LWP::Simple", "panda", "Shell::Command" ],
   "depends" : [ "NativeCall" ],
   "test-depends" : [ "Test" ],
   "provides" : {
     "Archive::Libarchive::Raw" : "lib/Archive/Libarchive/Raw.pm6",
     "Archive::Libarchive::Constants" : "lib/Archive/Libarchive/Constants.pm6"
   },
+  "resources" : [ "libarchive.dll" ],
   "authors" : [ "Fernando Santagata" ],
   "source-url" : "git://github.com/frithnanth/perl6-Archive-Libarchive-Raw"
 }

--- a/lib/Archive/Libarchive/Raw.pm6
+++ b/lib/Archive/Libarchive/Raw.pm6
@@ -3,7 +3,11 @@ unit module Archive::Libarchive::Raw:ver<0.0.1>;
 
 use NativeCall;
 
-constant LIB = %*ENV<PERL6_LIBARCHIVE_LIB> || 'libarchive.so.13';
+constant LIB = %*ENV<PERL6_LIBARCHIVE_LIB> || (
+    $*DISTRO.is-win
+        ?? %?RESOURCES<libarchive.dll>.abspath
+        !! 'libarchive.so.13'
+);
 
 class archive       is repr('CPointer') is export { * } # libarchive private struct
 class archive_entry is repr('CPointer') is export { * } # libarchive private struct

--- a/resources/libarchive.dll
+++ b/resources/libarchive.dll
@@ -1,0 +1,1 @@
+Stub file to be replaced with the real thing on Windows.


### PR DESCRIPTION
This takes the same approach as used in GTK::Simple: for Windows, host
a DLL, and include a hash in the module repo to make sure that the DLL
we download has not been tampered with. I've hosted the DLL on the Perl
6 community server, www.p6c.org.

I've verified that this does not break the Linux installation also.